### PR TITLE
Fix to install grunt with option to set versions

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -139,7 +139,8 @@ rm -rf "$build_dir/.npm"
     fi
 
     # make sure that grunt and grunt-cli are installed locally
-    npm install grunt-cli
+    npm install grunt-cli@${GRUNT_CLI_VERSION:-1.2.0}
+    npm install grunt@${GRUNT_VERSION:-^1.0.1}
     npm install
     echo "-----> Found Gruntfile, running grunt heroku:$NODE_ENV task"
     $build_dir/node_modules/.bin/grunt heroku:$NODE_ENV


### PR DESCRIPTION
Some how grunt was removed, I assume some grunt version related error
has been happened from branch name of "remove grunt" pull request, but
this cause an error on deploy into production environment; npm install
won't install dev dependencies when `NODE_ENV` is set as *production*

By this pull request, grunt will be installed in production environment
as well. Also, it support to change grunt version by giving environment
variable `GRUNT_CLI_VERSION` and `GRUNT_VERSION`. Default value is set
as latest version at this moment, so it might be better to update in
future.